### PR TITLE
Add insert tag {{avatar_url::member::*}} and parseAvatar changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Member avatars can be shown using following *insert-tags*
 {{avatar::member::current::200x200xproportional}}
 {{avatar::member::4}}
 {{avatar::member::4::300x300xcrop}}
+
+// Output file url
+{{avatar_url::member::current}}
+{{avatar_url::member:4}}
 ```
 
 The allowed image size parameters are:

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -26,7 +26,8 @@ use Oveleon\ContaoMemberExtensionBundle\Member;
 class InsertTagsListener
 {
     private const SUPPORTED_TAGS = [
-        'avatar'
+        'avatar',
+        'avatar_url'
     ];
 
     /**
@@ -83,14 +84,24 @@ class InsertTagsListener
                 break;
         }
 
-        if(!!$objMember = MemberModel::findByPk($memberID))
+        $objMember = MemberModel::findByPk($memberID);
+
+        switch ($insertTag)
         {
-            $strImgSize = $this->convertImgSize($elements[3]);
-            $objTemplate = new FrontendTemplate('memberExtension_image');
+            case 'avatar':
+            {
+                $strImgSize = $this->convertImgSize($elements[3]);
+                $objTemplate = new FrontendTemplate('memberExtension_image');
 
-            Member::parseMemberAvatar($objMember, $objTemplate, $strImgSize);
+                Member::parseMemberAvatar($objMember, $objTemplate, $strImgSize);
 
-            return $objTemplate->parse();
+                return $objTemplate->parse();
+            }
+
+            case 'avatar_url':
+            {
+                return Member::getMemberAvatarURL($objMember);
+            }
         }
 
         return '';

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -48,13 +48,13 @@ class InsertTagsListener
         $key = strtolower($elements[0]);
 
         if (\in_array($key, self::SUPPORTED_TAGS, true)) {
-            return $this->replaceEventInsertTag($key, $elements, $flags);
+            return $this->replaceMemberInsertTag($key, $elements, $flags);
         }
 
         return false;
     }
 
-    private function replaceEventInsertTag(string $insertTag, array $elements, array $flags): string
+    private function replaceMemberInsertTag(string $insertTag, array $elements, array $flags): string
     {
         $this->framework->initialize();
         $tokenChecker = System::getContainer()->get('contao.security.token_checker');

--- a/src/Resources/contao/modules/ModuleMemberExtension.php
+++ b/src/Resources/contao/modules/ModuleMemberExtension.php
@@ -16,8 +16,9 @@ declare(strict_types=1);
 namespace Oveleon\ContaoMemberExtensionBundle;
 
 use Contao\Config;
+use Contao\Date;
 use Contao\Environment;
-use Contao\FilesModel;
+use Contao\MemberGroupModel;
 use Contao\MemberModel;
 use Contao\Module;
 use Contao\PageModel;
@@ -40,14 +41,23 @@ abstract class ModuleMemberExtension extends Module
      * @param $strImgSize
      * @return string
      */
-    protected function parseMemberTemplate($objMember, $objTemplate, $arrMemberFields, $strImgSize)
+    protected function parseMemberTemplate($objMember, $objTemplate, $arrMemberFields, $strImgSize): string
     {
+        System::loadLanguageFile('default');
+        System::loadLanguageFile('tl_member');
+        System::loadLanguageFile('countries');
+        System::loadLanguageFile('languages');
+
         $arrFields = [];
 
         foreach ($arrMemberFields as $field)
         {
             switch($field)
             {
+                /*case 'homeDir':
+                case 'assignDir':
+                    break;*/
+
                 case 'avatar':
                     Member::parseMemberAvatar($objMember, $objTemplate, $strImgSize);
                     break;
@@ -55,14 +65,7 @@ abstract class ModuleMemberExtension extends Module
                 default:
                     if($varValue = $objMember->{$field})
                     {
-                        if (\is_array(($arrValue = StringUtil::deserialize($varValue))))
-                        {
-                            $arrFields[$field] = implode(",", $arrValue);
-                        }
-                        else
-                        {
-                            $arrFields[$field] = $varValue;
-                        }
+                        self::parseMemberDetails($arrFields, $field, $varValue);
                     }
             }
         }
@@ -84,7 +87,7 @@ abstract class ModuleMemberExtension extends Module
      *
      * @return string
      */
-    protected function generateMemberUrl($objMember)
+    protected function generateMemberUrl(MemberModel $objMember): string
     {
         $objPage = PageModel::findPublishedById($this->jumpTo);
 
@@ -99,5 +102,69 @@ abstract class ModuleMemberExtension extends Module
         }
 
         return $strLink;
+    }
+
+    protected function parseMemberDetails(&$arrFields, $field, $value)
+    {
+        $strReturn = sprintf('<span class="label">%s: </span>',$GLOBALS['TL_LANG']['tl_member'][$field][0] ?? null);
+
+        if (!\is_array(($arrValue = StringUtil::deserialize($value))))
+        {
+            switch ($field) {
+                case 'gender':
+                    $strReturn .= $GLOBALS['TL_LANG']['MSC'][$value] ?? $value;
+                    break;
+
+                case 'email':
+                    $strEmail = StringUtil::encodeEmail($value);
+                    $strReturn .= '<a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;' . $strEmail . '" title="' . $strEmail . '">' . preg_replace('/\?.*$/', '', $strEmail) . '</a>';
+                    break;
+
+                case 'phone':
+                case 'mobile':
+                case 'fax':
+                    $strTel = preg_replace('/[^a-z\d+]/i', '', (string)$value);
+                    $strReturn .= '<a href="tel:' . $strTel . '" title="' . $value . '">' . $value . '</a>';
+                    break;
+
+                case 'website':
+                    $strUrl = $value;
+
+                    if (strncmp($value, 'http://', 7) !== 0 || strncmp($value, 'https://', 8) !== 0) {
+                        $strUrl = 'https://' . $value;
+                    }
+
+                    $strReturn .= '<a href="' . $strUrl . '" title="' . $value . '" target="blank noopener" rel="noreferer">' . $value . '</a>';
+                    break;
+
+                case 'dateOfBirth':
+                    $strReturn .= Date::parse(Config::get('dateFormat'), $value) ?? $value;
+                    break;
+
+                case 'country':
+                    $strReturn .= $GLOBALS['TL_LANG']['CNT'][$value] ?? $value;
+                    break;
+
+                case 'language':
+                    $strReturn .= $GLOBALS['TL_LANG']['LNG'][$value] ?? $value;
+                    break;
+
+                default:
+                    $strReturn .= $value;
+            }
+        }
+        else if ('groups' === $field)
+        {
+            $arrReturn = [];
+
+            foreach ($arrValue as $value)
+            {
+                $arrReturn[] = MemberGroupModel::findById($value)->name;
+            }
+
+            $strReturn .= implode(", ", $arrReturn);
+        }
+
+        $arrFields[$field] = $strReturn;
     }
 }


### PR DESCRIPTION
This PR adds a new insert tag `{{avatar_url::member::*}}` to output the filepath of member avatars.

Additionally, a bug has been fixed where the fallback image from member settings was not considered in the following edge cases:
- memberID within inserttag {{avatar::member::*}} did not exist
- the uuid of the avatar was present but the file did not exist