### PR TITLE
Fix PHP warning in 'Personal Data' module

### DIFF
--- a/contao/classes/Member.php
+++ b/contao/classes/Member.php
@@ -68,8 +68,11 @@ class Member extends Frontend
     {
         $objMember = MemberModel::findByPk($objMember->id);
 
-        if ($objMember === null || !array_key_exists('FILES', $_SESSION))
-        {
+        if (
+            $objMember === null ||
+            !array_key_exists('FILES', $_SESSION) ||
+            !isset($_SESSION['FILES']['avatar'])
+        ) {
             return;
         }
 

--- a/contao/classes/Member.php
+++ b/contao/classes/Member.php
@@ -68,7 +68,7 @@ class Member extends Frontend
     {
         $objMember = MemberModel::findByPk($objMember->id);
 
-        if ($objMember === null)
+        if ($objMember === null || !array_key_exists('FILES', $_SESSION))
         {
             return;
         }


### PR DESCRIPTION
This commit addresses a PHP warning observed in the 'Personal Data' module when using the 'Avatar' field. The warning "Warning: Undefined array key 'FILES'" was encountered under specific circumstances.

Issue Description:
The warning surfaced when attempting to save the form in the frontend without selecting an image for the avatar. In such cases, the 'FILES' key does not exist within the $_SESSION array, leading to an undefined array key warning.

Resolution:
The condition in the relevant if-statement has been updated to include a check for the existence of the 'FILES' key in the $_SESSION array. This change ensures that the function returns early if either $objMember is null or the 'FILES' key is absent, thereby preventing the warning.

This modification effectively resolves the PHP warning while maintaining the existing functionality of the module.